### PR TITLE
Fix consumer test for CI

### DIFF
--- a/ChatApp/tests/test_consumers.py
+++ b/ChatApp/tests/test_consumers.py
@@ -1,25 +1,41 @@
-import json
-import pytest
+from asgiref.sync import async_to_sync
 from channels.testing import WebsocketCommunicator
+from django.test import TransactionTestCase
+from unittest.mock import patch, MagicMock
+
 from WebSocketChatApp.routing import application
 from ChatApp.models import CustomUser, Conversation, Message
 
-@pytest.mark.asyncio
-async def test_message_persistence(db):
-    user1 = CustomUser.objects.create_user(email="cuser1@example.com", password="pass")
-    user2 = CustomUser.objects.create_user(email="cuser2@example.com", password="pass")
-    conversation = Conversation.objects.create(user1=user1, user2=user2)
 
-    communicator = WebsocketCommunicator(application, f"ws/chat/{conversation.id}/")
-    communicator.scope['user'] = user1
+class ChatConsumerTestCase(TransactionTestCase):
+    def test_message_persistence(self):
+        user1 = CustomUser.objects.create_user(email="cuser1@example.com", password="pass")
+        user2 = CustomUser.objects.create_user(email="cuser2@example.com", password="pass")
+        conversation = Conversation.objects.create(user1=user1, user2=user2)
 
-    connected, _ = await communicator.connect()
-    assert connected
+        async def inner():
+            with patch('ChatApp.consumers.redis.StrictRedis') as mock_redis:
+                mock_client = MagicMock()
+                mock_redis.return_value.__enter__.return_value = mock_client
 
-    await communicator.send_json_to({'message': 'hello'})
-    response = await communicator.receive_json_from()
-    assert response['message'] == 'hello'
+                communicator = WebsocketCommunicator(application, f"ws/chat/{conversation.id}/")
+                communicator.scope['user'] = user1
 
-    await communicator.disconnect()
+                connected, _ = await communicator.connect()
+                assert connected
 
-    assert Message.objects.filter(conversation=conversation, sender=user1, content='hello').exists()
+                await communicator.send_json_to({'message': 'hello'})
+                response = await communicator.receive_json_from()
+                assert response['message'] == 'hello'
+
+                await communicator.disconnect()
+
+        async_to_sync(inner)()
+
+        self.assertTrue(
+            Message.objects.filter(
+                conversation=conversation,
+                sender=user1,
+                content='hello'
+            ).exists()
+        )


### PR DESCRIPTION
## Summary
- refactor Chat consumer test to run without pytest
- patch redis usage during the test

## Testing
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`

------
https://chatgpt.com/codex/tasks/task_e_68406551a580832ab928f247d1daf331