### PR TITLE
Add Prometheus/Grafana observability

### DIFF
--- a/ChatApp/consumers.py
+++ b/ChatApp/consumers.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.conf import settings
 from .models import Conversation, Message
 from .dlp import run_dlp_hook
+from WebSocketChatApp.telemetry import record_websocket_latency
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     async def chat_message(self, event):
         message = event["message"]
+
+        start_time = timezone.datetime.fromisoformat(event["timestamp"])
+        latency_ms = (timezone.now() - start_time).total_seconds() * 1000
+        record_websocket_latency(latency_ms)
 
         await self.send(text_data=json.dumps({
             "message": message,

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The WebSocket Chat Application demonstrates real-time messaging using Django, Dj
 - SCIM-based user provisioning
 - Role-based access control (Owner, Admin, Analyst)
 - Dockerised services for the application, MySQL database and Redis
+- Real-time telemetry with OpenTelemetry, Prometheus and Grafana
 
 ## Quick Start
 ### Prerequisites
@@ -35,6 +36,11 @@ docker-compose build
 docker-compose up
 ```
 The application will be available at `http://localhost:8000`.
+
+Prometheus will expose metrics on `http://localhost:9090` and Grafana will be available at `http://localhost:3000` (default credentials `admin`/`admin`).
+
+## Telemetry
+Metrics are exported using OpenTelemetry and Prometheus. Grafana Live can be used to visualise latency in real time. The Prometheus scrape endpoint is exposed on port `8001` from the Django container.
 
 ## Running Tests
 Use SQLite and the in-memory channel layer when executing tests:

--- a/WebSocketChatApp/asgi.py
+++ b/WebSocketChatApp/asgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.asgi import get_asgi_application
 
+# Initialize OpenTelemetry instrumentation
+from . import telemetry  # noqa: F401
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebSocketChatApp.settings')
 
 application = get_asgi_application()

--- a/WebSocketChatApp/telemetry.py
+++ b/WebSocketChatApp/telemetry.py
@@ -1,0 +1,26 @@
+import os
+from opentelemetry import metrics
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from prometheus_client import start_http_server
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+metrics_port = int(os.getenv("METRICS_PORT", "8001"))
+start_http_server(port=metrics_port)
+
+_reader = PrometheusMetricReader()
+_provider = MeterProvider(metric_readers=[_reader])
+metrics.set_meter_provider(_provider)
+
+DjangoInstrumentor().instrument()
+
+_meter = metrics.get_meter("chatapp")
+websocket_latency_histogram = _meter.create_histogram(
+    "chatapp.websocket.message_latency_ms",
+    unit="ms",
+    description="Latency of WebSocket message delivery",
+)
+
+
+def record_websocket_latency(duration_ms: float):
+    websocket_latency_histogram.record(duration_ms)

--- a/WebSocketChatApp/wsgi.py
+++ b/WebSocketChatApp/wsgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+# Initialize OpenTelemetry instrumentation
+from . import telemetry  # noqa: F401
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebSocketChatApp.settings')
 
 application = get_wsgi_application()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: chatapp-django
     ports:
       - "8000:8000"
+      - "8001:8001"
     volumes:
       - .:/app
     depends_on:
@@ -13,6 +14,7 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: WebSocketChatApp.settings
       DEBUG: "True"
+      METRICS_PORT: "8001"
     healthcheck:
       test: [ "CMD", "python", "manage.py", "check" ]
       interval: 30s
@@ -39,5 +41,29 @@ services:
     ports:
       - "6379:6379"
 
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - chatapp-django
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SECURITY_ADMIN_PASSWORD: "admin"
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana_data:/var/lib/grafana
+
 volumes:
   mysql_data:
+  grafana_data:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'chatapp'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['chatapp-django:8001']

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,8 @@ pyotp~=2.9.0
 kafka-python~=2.0.2
 PyJWT~=2.8.0
 boto3~=1.34.0
+opentelemetry-api~=1.34.0
+opentelemetry-sdk~=1.34.0
+opentelemetry-exporter-prometheus==0.55b0
+opentelemetry-instrumentation-django==0.55b0
+prometheus-client~=0.22.1


### PR DESCRIPTION
## Summary
- export metrics using OpenTelemetry and Prometheus
- measure websocket latency and collect http metrics
- expose metrics port and add Prometheus/Grafana services
- document telemetry endpoints

## Testing
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings -v 1`

------
https://chatgpt.com/codex/tasks/task_e_6840b1a86398832a939d92c9a766d68a