### PR TITLE
Add double-ratchet note and KMS key helpers

### DIFF
--- a/ChatApp/kms.py
+++ b/ChatApp/kms.py
@@ -1,0 +1,45 @@
+"""Helper utilities for retrieving tenant encryption keys from AWS KMS."""
+
+from __future__ import annotations
+
+import base64
+from typing import Tuple
+
+import boto3
+from django.conf import settings
+
+_kms_client = None
+
+
+def get_kms_client():
+    """Return a cached boto3 KMS client."""
+    global _kms_client
+    if _kms_client is None:
+        region = getattr(settings, "AWS_REGION", "us-east-1")
+        _kms_client = boto3.client("kms", region_name=region)
+    return _kms_client
+
+
+def generate_data_key() -> Tuple[bytes, str]:
+    """Generate a data key using the configured CMK.
+
+    Returns the plaintext key and the base64 encoded ciphertext blob so that the
+    ciphertext can be stored alongside encrypted data.
+    """
+    key_id = getattr(settings, "KMS_KEY_ID", None)
+    if not key_id:
+        raise ValueError("KMS_KEY_ID is not configured")
+
+    client = get_kms_client()
+    response = client.generate_data_key(KeyId=key_id, KeySpec="AES_256")
+    plaintext = response["Plaintext"]
+    ciphertext = base64.b64encode(response["CiphertextBlob"]).decode("utf-8")
+    return plaintext, ciphertext
+
+
+def decrypt_data_key(ciphertext_b64: str) -> bytes:
+    """Decrypt a base64 encoded ciphertext blob and return the plaintext key."""
+    client = get_kms_client()
+    ciphertext = base64.b64decode(ciphertext_b64)
+    response = client.decrypt(CiphertextBlob=ciphertext)
+    return response["Plaintext"]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ The WebSocket Chat Application demonstrates real-time messaging using Django, Dj
 - Message sanitisation and length checks for extra security
 - WebSocket connections automatically use `wss://` when the site is served over HTTPS
 - Typing indicators show when participants are composing a message
-- Optional end-to-end encryption for 1-to-1 chats using X25519 key exchange
-- Group conversations secured at rest with BYOK-managed keys
+- End-to-end encryption for 1-to-1 chats uses the double-ratchet algorithm with
+  an X25519 handshake. Messages are encrypted client-side before being sent.
+- Group conversations are encrypted at rest with BYOK-managed keys. Tenant keys
+  are stored in AWS KMS following a pattern similar to Slack EKM.
 - Pluggable data-loss-prevention hooks scan outgoing messages
 - Per-room retention policies with legal hold and S3 export
 - Ephemeral messages that self-destruct after a short TTL
@@ -90,6 +92,7 @@ MYSQL_PASSWORD=<db password>
 MYSQL_HOST=chatapp-db
 REDIS_HOST=chatapp-redis
 MESSAGE_ENCRYPTION_KEY=<base64 key for BYOK>
+KMS_KEY_ID=<AWS KMS key ID for BYOK/EKM>
 DLP_BEFORE_SEND_HOOK=ChatApp.dlp.default_dlp_callback
 NIGHTFALL_API_KEY=<optional Nightfall API key>
 ORG_RETENTION_DAYS=30

--- a/WebSocketChatApp/settings.py
+++ b/WebSocketChatApp/settings.py
@@ -203,6 +203,9 @@ MESSAGE_MAX_LENGTH = int(os.getenv('MESSAGE_MAX_LENGTH', '500'))
 # Base64 encoded key used for BYOK encryption of group chats
 MESSAGE_ENCRYPTION_KEY = os.getenv('MESSAGE_ENCRYPTION_KEY')
 
+# AWS KMS CMK used to envelope-encrypt tenant keys (Slack EKM pattern)
+KMS_KEY_ID = os.getenv('KMS_KEY_ID')
+
 # Import path to a callable used for DLP checks before sending messages
 DLP_BEFORE_SEND_HOOK = os.getenv(
     'DLP_BEFORE_SEND_HOOK', 'ChatApp.dlp.default_dlp_callback'

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ opentelemetry-sdk~=1.34.0
 opentelemetry-exporter-prometheus==0.55b0
 opentelemetry-instrumentation-django==0.55b0
 prometheus-client~=0.22.1
+doubleratchet==1.0.4


### PR DESCRIPTION
## Summary
- describe double-ratchet E2EE and BYOK KMS storage in README
- add KMS_KEY_ID env var in settings
- helper utilities for retrieving tenant keys from AWS KMS
- include doubleratchet lib in requirements

## Testing
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`

------