### PR TITLE
Add Grafana dashboard and metrics endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Prometheus will expose metrics on `http://localhost:9090` and Grafana will be av
 
 ## Telemetry
 Metrics are exported using OpenTelemetry and Prometheus. Grafana Live can be used to visualise latency in real time. The Prometheus scrape endpoint is exposed on port `8001` from the Django container.
+The metrics HTTP server exposes `/metrics` so Prometheus can scrape `http://localhost:8001/metrics`.
+Import `docs/grafana-dashboard.json` into Grafana to view a panel showing the P95 WebSocket latency.
 
 Tracing is also enabled. Run the app with:
 ```bash

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,0 +1,44 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "milliseconds"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      },
+      "title": "P95 WebSocket Latency",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(chatapp_websocket_message_latency_ms_bucket[5m])) by (le))",
+          "legendFormat": "p95 latency",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "title": "ChatApp Latency",
+  "version": 1
+}


### PR DESCRIPTION
## Summary
- document the Prometheus `/metrics` endpoint
- provide a Grafana dashboard for P95 WebSocket latency

## Testing
- `pip install -r requirements.txt`
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`


------