### PR TITLE
Add environment values for Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ helm install chatapp ./deploy/helm \
   --set saml.configPath=/etc/saml/config.json \
   --set scim.bearerToken=$SCIM_TOKEN
 ```
+Environment specific values are provided. Select a file with `-f`:
+```bash
+helm install chatapp ./deploy/helm -f deploy/helm/values-dev.yaml
+# or
+helm install chatapp ./deploy/helm -f deploy/helm/values-prod.yaml
+```
 The chart provisions MySQL and Redis alongside the Django application so you can get running in minutes.
 
 ### Kustomize Overlays

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 name: chatapp
 version: 0.1.0
 description: WebSocket Chat Application
-appVersion: "1.0"
 type: application
+appVersion: "1.0"
+kubeVersion: ">=1.21.0-0"
+maintainers:
+  - name: ChatApp Maintainer
+    email: maintainers@example.com

--- a/deploy/helm/values-dev.yaml
+++ b/deploy/helm/values-dev.yaml
@@ -1,0 +1,27 @@
+image:
+  repository: modrix/chatapp-django-image
+  tag: dev
+  pullPolicy: IfNotPresent
+
+mysql:
+  image: mysql:5.7
+  database: chatapp_dev
+  user: chatapp_dev
+  password: devpassword
+  rootPassword: devrootpassword
+
+redis:
+  image: redis:6.2
+
+service:
+  type: NodePort
+  port: 8000
+
+saml:
+  configPath: ""
+
+scim:
+  bearerToken: devtoken
+
+encryption:
+  key: devkey

--- a/deploy/helm/values-prod.yaml
+++ b/deploy/helm/values-prod.yaml
@@ -1,0 +1,27 @@
+image:
+  repository: modrix/chatapp-django-image
+  tag: v1.0
+  pullPolicy: IfNotPresent
+
+mysql:
+  image: mysql:5.7
+  database: chatapp
+  user: chatapp
+  password: prodpassword
+  rootPassword: prodrootpassword
+
+redis:
+  image: redis:6.2
+
+service:
+  type: LoadBalancer
+  port: 8000
+
+saml:
+  configPath: ""
+
+scim:
+  bearerToken: prodtoken
+
+encryption:
+  key: prodkey


### PR DESCRIPTION
## Summary
- add environment-specific helm values files
- note helm files in README
- add kube version & maintainer info to Chart.yaml

## Testing
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`
- `helm lint deploy/helm` *(fails: helm command not found)*

------