### PR TITLE
Add graceful shutdown and security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,42 @@
+name: Security Checks
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.11'
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install bandit cyclonedx-bom
+      - name: Bandit Scan
+        run: bandit -r ChatApp WebSocketChatApp -f json -o bandit-report.json
+      - name: Trivy File Scan
+        uses: aquasecurity/trivy-action@v0.17.0
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          output: trivy-report.txt
+      - name: Generate SBOM
+        run: cyclonedx-py -o sbom.xml
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: security-reports
+          path: |
+            bandit-report.json
+            trivy-report.txt
+            sbom.xml
+

--- a/ChatApp/consumers.py
+++ b/ChatApp/consumers.py
@@ -18,6 +18,34 @@ from WebSocketChatApp.telemetry import record_websocket_latency
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
+redis_client = redis.Redis(
+    host=getattr(settings, "REDIS_HOST", "localhost"),
+    port=int(getattr(settings, "REDIS_PORT", 6379)),
+    decode_responses=True,
+)
+
+
+@database_sync_to_async
+def register_conversation(cid: str):
+    try:
+        backend = settings.CHANNEL_LAYERS["default"].get("BACKEND", "")
+        if backend.endswith("InMemoryChannelLayer"):
+            return
+        redis_client.sadd("active_conversations", cid)
+    except Exception:
+        pass
+
+
+@database_sync_to_async
+def unregister_conversation(cid: str):
+    try:
+        backend = settings.CHANNEL_LAYERS["default"].get("BACKEND", "")
+        if backend.endswith("InMemoryChannelLayer"):
+            return
+        redis_client.srem("active_conversations", cid)
+    except Exception:
+        pass
+
 
 def check_rate_limit(rate, method='RATELIMIT_KEY'):
     def decorator(func):
@@ -69,19 +97,24 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 await self.close()
                 return
 
-            await self.channel_layer.group_add(
-                self.conversation_group_name,
-                self.channel_name
-            )
+        await self.channel_layer.group_add(
+            self.conversation_group_name,
+            self.channel_name
+        )
 
-            await self.accept()
-            logger.info(f"User {self.scope['user']} connected to conversation {self.conversation_id}")
+        await register_conversation(str(self.conversation_id))
+
+        await self.accept()
+        logger.info(
+            f"User {self.scope['user']} connected to conversation {self.conversation_id}"
+        )
 
     async def disconnect(self, close_code):
         await self.channel_layer.group_discard(
             self.conversation_group_name,
             self.channel_name
         )
+        await unregister_conversation(str(self.conversation_id))
         logger.info(f"User {self.scope['user']} disconnected from conversation {self.conversation_id}")
 
     @check_rate_limit(rate=1)
@@ -215,4 +248,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
             "sender_email": event.get("sender_email"),
             "key": event.get("key"),
         }))
+
+    async def chat_pre_stop(self, event):
+        await self.close(code=1001)
 

--- a/ChatApp/management/commands/pre_stop.py
+++ b/ChatApp/management/commands/pre_stop.py
@@ -1,0 +1,19 @@
+from django.core.management.base import BaseCommand
+from django.conf import settings
+from channels.layers import get_channel_layer
+from asgiref.sync import async_to_sync
+import redis
+
+class Command(BaseCommand):
+    help = "Notify all active WebSocket connections of shutdown"
+
+    def handle(self, *args, **options):
+        redis_host = getattr(settings, "REDIS_HOST", "localhost")
+        redis_port = int(getattr(settings, "REDIS_PORT", 6379))
+        client = redis.Redis(host=redis_host, port=redis_port, decode_responses=True)
+        groups = client.smembers("active_conversations")
+        channel_layer = get_channel_layer()
+        for cid in groups:
+            async_to_sync(channel_layer.group_send)(f"chat_{cid}", {"type": "chat.pre_stop"})
+        self.stdout.write(self.style.SUCCESS("Sent shutdown to WebSocket groups"))
+

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: {{ include "chatapp.name" . }}
     spec:
+      terminationGracePeriodSeconds: 15
       containers:
         - name: chatapp
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -53,3 +54,7 @@ spec:
           ports:
             - containerPort: 8000
           command: ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "/app/scripts/pre_stop.sh"]

--- a/scripts/pre_stop.sh
+++ b/scripts/pre_stop.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+python manage.py pre_stop --settings=WebSocketChatApp.settings
+sleep 5


### PR DESCRIPTION
## Summary
- add Redis-driven connection registry to allow lifecycle preStop to signal clients
- implement `pre_stop` management command
- create script executed by preStop hook
- update Helm deployment with lifecycle hook and termination grace period
- add GitHub Actions security workflow running Bandit, Trivy and SBOM generation

## Testing
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`

------