### PR TITLE
Add Daphne server and JSON logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ EXPOSE 8000
 
 ENV NAME World
 
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["daphne", "-b", "0.0.0.0", "-p", "8000", "WebSocketChatApp.asgi:application"]
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The WebSocket Chat Application demonstrates real-time messaging using Django, Dj
 - Immutable, SHA-chained audit logs streamed to Kafka for SIEM integration
 - Enterprise identity via SAML 2.0 and OpenID Connect
 - SCIM-based user provisioning
+- Content Security Policy enforcement via `django-csp`
+- Structured JSON logging for SIEM integration
+- Production-ready ASGI server powered by Daphne
 - Role-based access control (Owner, Admin, Analyst)
 - Dockerised services for the application, MySQL database and Redis
 - Real-time telemetry with OpenTelemetry, Prometheus and Grafana
@@ -38,7 +41,7 @@ cd WebSocket-ChatApp
 docker-compose build
 docker-compose up
 ```
-The application will be available at `http://localhost:8000`.
+The application will be available at `http://localhost:8000` and served by the Daphne ASGI server for optimal WebSocket performance.
 
 Prometheus will expose metrics on `http://localhost:9090` and Grafana will be available at `http://localhost:3000` (default credentials `admin`/`admin`).
 
@@ -50,7 +53,7 @@ Import `docs/grafana-dashboard.json` into Grafana to view a panel showing the P9
 Tracing is also enabled. Run the app with:
 ```bash
 OTEL_PYTHON_TRACER_PROVIDER=WebSocketChatApp.console_tracer_provider:tracer_provider \
-opentelemetry-instrument python manage.py runserver --settings=WebSocketChatApp.test_settings
+opentelemetry-instrument daphne -b 0.0.0.0 WebSocketChatApp.asgi:application
 ```
 Traces will be printed to STDOUT showing spans for WebSocket connect, receive and database writes.
 
@@ -94,6 +97,8 @@ Example overlays are located in `deploy/kustomize/overlays/`. Build the base man
 kustomize build deploy/kustomize/overlays/example | kubectl apply -f -
 ```
 
+Further guidance on horizontal scaling and enterprise deployment is available in [docs/scaling.md](docs/scaling.md).
+
 ## Security Configuration
 A checklist of common security considerations is available in [OWASP_SECURITY.md](OWASP_SECURITY.md). Sensitive settings are read from environment variables such as:
 ```
@@ -123,6 +128,8 @@ OIDC_CLIENT_ID=<OIDC client id>
 OIDC_CLIENT_SECRET=<OIDC client secret>
 SCIM_BEARER_TOKEN=<token for SCIM auth>
 TOTP_ENFORCE=True
+LOG_JSON=False  # set to True for structured logs
+CSP_REPORT_ONLY=False  # enable report-only mode for CSP
 ```
 Ensure HTTPS is enabled and cookies are transmitted securely.
 

--- a/WebSocketChatApp/settings.py
+++ b/WebSocketChatApp/settings.py
@@ -35,12 +35,14 @@ INSTALLED_APPS = [
     'djangosaml2',
     'django_scim',
     'channels',
+    'csp',
     'ChatApp',
 ]
 
 MIDDLEWARE = [
     'django_ratelimit.middleware.RatelimitMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'csp.middleware.CSPMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -197,6 +199,12 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True
 CSRF_TRUSTED_ORIGINS = [origin for origin in os.getenv('DJANGO_CSRF_TRUSTED_ORIGINS', '').split(',') if origin]
 
+# Content Security Policy
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_STYLE_SRC = ("'self'",)
+CSP_SCRIPT_SRC = ("'self'",)
+CSP_REPORT_ONLY = os.getenv('CSP_REPORT_ONLY', 'False').lower() in ('true', '1', 'yes')
+
 # Maximum allowed characters in a chat message
 MESSAGE_MAX_LENGTH = int(os.getenv('MESSAGE_MAX_LENGTH', '500'))
 
@@ -242,17 +250,18 @@ CELERY_BEAT_SCHEDULE = {
 # Logging
 
 LOGGING_DIR = BASE_DIR / 'logs'
+LOG_JSON = os.getenv('LOG_JSON', 'False').lower() in ('true', '1', 'yes')
 
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
+        'json': {
+            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+            'fmt': '%(levelname)s %(asctime)s %(module)s %(message)s',
+        },
         'verbose': {
             'format': '{levelname} {asctime} {module} {message}',
-            'style': '{',
-        },
-        'simple': {
-            'format': '{levelname} {message}',
             'style': '{',
         },
     },
@@ -261,17 +270,21 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
             'filename': str(LOGGING_DIR / 'logging.log'),
-            'formatter': 'verbose',
+            'formatter': 'json' if LOG_JSON else 'verbose',
+        },
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'json' if LOG_JSON else 'verbose',
         },
     },
     'loggers': {
         'django': {
-            'handlers': ['file'],
+            'handlers': ['console', 'file'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'ChatApp': {
-            'handlers': ['file'],
+            'handlers': ['console', 'file'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   key: scim-token
           ports:
             - containerPort: 8000
-          command: ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+          command: ["sh", "-c", "python manage.py migrate && daphne -b 0.0.0.0 -p 8000 WebSocketChatApp.asgi:application"]
           lifecycle:
             preStop:
               exec:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-    command: ["sh", "-c", "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+    command: ["sh", "-c", "python manage.py migrate && daphne -b 0.0.0.0 -p 8000 WebSocketChatApp.asgi:application"]
 
   chatapp-db:
     image: mysql:5.7

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,23 @@
+# Scaling WebSocket ChatApp
+
+This document outlines common approaches for horizontally scaling the chat application and securing deployments for enterprise environments. The container and Kubernetes manifests use **Daphne** as the ASGI server to maximise concurrency for WebSocket traffic.
+
+## Horizontal Pod Autoscaling
+- Deploy the application on Kubernetes using the provided Helm chart or Kustomize overlays.
+- Enable a HorizontalPodAutoscaler to automatically adjust the number of Daphne worker pods based on CPU or custom metrics.
+- Redis and MySQL can be run in managed services like Amazon ElastiCache and RDS for better reliability.
+
+## Database and Cache
+- Use a managed MySQL cluster with primary/replica topology.
+- Configure Redis in a highly available mode with persistence enabled.
+
+## Security Considerations
+- Enforce HTTPS everywhere and terminate TLS with a modern cipher suite.
+- Rotate secrets using your cloud provider's secret manager.
+- Review [`OWASP_SECURITY.md`](../OWASP_SECURITY.md) for a checklist of common hardening steps.
+
+## Observability
+- Export metrics to Prometheus as shown in `prometheus.yml` and visualise them with Grafana.
+- Enable tracing via OpenTelemetry for deeper insights into latency bottlenecks.
+
+When running multiple Daphne instances, route traffic through a load balancer that supports sticky sessions or configure Redis as the channel layer's backend for shared state. These guidelines provide a baseline for operating the application at scale in production environments.

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ opentelemetry-instrumentation-django==0.55b0
 prometheus-client~=0.22.1
 doubleratchet==1.0.4
 requests~=2.31
+django-csp~=3.7
+daphne>=3,<4
+python-json-logger~=3.3


### PR DESCRIPTION
## Summary
- run the app with Daphne for production-ready ASGI support
- enable optional JSON logging via `python-json-logger`
- document scaling with Daphne and add environment variables
- update Docker/Kubernetes configs to use Daphne

## Testing
- `pip install -r requirements.txt`
- `python manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings --verbosity=1`

------
https://chatgpt.com/codex/tasks/task_e_68447c43c444832a998f60b79de8eb6f