### PR TITLE
Add blue/green kustomize overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ Example overlays are located in `deploy/kustomize/overlays/`. Build the base man
 kustomize build deploy/kustomize/overlays/example | kubectl apply -f -
 ```
 
+Blue/green deployment manifests are also available:
+
+```bash
+kustomize build deploy/kustomize/overlays/blue | kubectl apply -f -
+kustomize build deploy/kustomize/overlays/green | kubectl apply -f -
+```
+
+After verifying the green rollout, run `scripts/rollout_to_green.sh` to shift
+all traffic to the green service.
+
 Further guidance on horizontal scaling and enterprise deployment is available in [docs/scaling.md](docs/scaling.md).
 
 ## Security Configuration

--- a/deploy/kustomize/overlays/blue/kustomization.yaml
+++ b/deploy/kustomize/overlays/blue/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../../base
+helmCharts:
+  - name: chatapp
+    path: ../../../helm
+    releaseName: chatapp-blue
+    valuesFile: ../../../helm/values.yaml
+
+patchesStrategicMerge:
+  - service-weight.yaml

--- a/deploy/kustomize/overlays/blue/service-weight.yaml
+++ b/deploy/kustomize/overlays/blue/service-weight.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chatapp-blue-chatapp
+  annotations:
+    traefik.ingress.kubernetes.io/weight: "95"

--- a/deploy/kustomize/overlays/green/kustomization.yaml
+++ b/deploy/kustomize/overlays/green/kustomization.yaml
@@ -1,0 +1,9 @@
+bases:
+  - ../../base
+helmCharts:
+  - name: chatapp
+    path: ../../../helm
+    releaseName: chatapp-green
+    valuesFile: ../../../helm/values.yaml
+patchesStrategicMerge:
+  - service-canary.yaml

--- a/deploy/kustomize/overlays/green/service-canary.yaml
+++ b/deploy/kustomize/overlays/green/service-canary.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: chatapp-green-chatapp
+  annotations:
+    traefik.ingress.kubernetes.io/weight: "5"

--- a/scripts/rollout_to_green.sh
+++ b/scripts/rollout_to_green.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+NAMESPACE=${NAMESPACE:-default}
+BLUE_DEPLOYMENT=chatapp-blue-chatapp
+GREEN_DEPLOYMENT=chatapp-green-chatapp
+
+# Wait for green deployment rollout
+kubectl rollout status deployment/$GREEN_DEPLOYMENT -n $NAMESPACE
+
+# Shift traffic fully to green
+kubectl annotate service $GREEN_DEPLOYMENT traefik.ingress.kubernetes.io/weight=100 --overwrite -n $NAMESPACE
+kubectl annotate service $BLUE_DEPLOYMENT traefik.ingress.kubernetes.io/weight=0 --overwrite -n $NAMESPACE
+


### PR DESCRIPTION
## Summary
- add blue & green overlays for kustomize canary deployments
- annotate service with Traefik weight for canary
- add rollout_to_green.sh helper script
- document how to apply the overlays

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt`
- `pytest -q` *(fails: AttributeError: module 'collections' has no attribute 'MutableSet')*

------
https://chatgpt.com/codex/tasks/task_e_6844b6ed7514832a981e008bb264307d