### PR TITLE
Add GDPR export and erase functionality

### DIFF
--- a/ChatApp/api_urls.py
+++ b/ChatApp/api_urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from .api_views import RetentionPolicyListCreateView, ReceiptView
+from .api_views import (
+    RetentionPolicyListCreateView,
+    ReceiptView,
+    EraseUserDataView,
+)
 
 urlpatterns = [
     path('retention/', RetentionPolicyListCreateView.as_view(), name='retention'),
     path('receipts/', ReceiptView.as_view(), name='receipts'),
+    path('gdpr/erase/', EraseUserDataView.as_view(), name='gdpr-erase'),
 ]

--- a/ChatApp/api_views.py
+++ b/ChatApp/api_views.py
@@ -2,8 +2,14 @@ from rest_framework import generics, permissions, views
 from rest_framework.response import Response
 from django.db.models import Q
 
-from ChatApp.models import RetentionPolicy, Conversation, Message, MessageReceipt
+from ChatApp.models import (
+    RetentionPolicy,
+    Conversation,
+    Message,
+    MessageReceipt,
+)
 from ChatApp.serializers import RetentionPolicySerializer
+from ChatApp.tasks import erase_user_data
 
 
 class RetentionPolicyListCreateView(generics.ListCreateAPIView):
@@ -28,3 +34,15 @@ class ReceiptView(views.APIView):
             unread = Message.objects.filter(conversation=c, id__gt=last_seen).count()
             data.append({"conversation_id": c.id, "unread": unread})
         return Response(data)
+
+
+class EraseUserDataView(views.APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        confirm = request.data.get("confirm")
+        if confirm != request.user.email:
+            return Response({"detail": "Email confirmation mismatch."}, status=400)
+
+        erase_user_data.apply_async((request.user.id,), countdown=30 * 24 * 60 * 60)
+        return Response({"status": "scheduled"})

--- a/ChatApp/management/commands/export_user_data.py
+++ b/ChatApp/management/commands/export_user_data.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core import serializers
+from django.db.models import Q
+import json
+import zipfile
+from io import BytesIO
+
+from ChatApp.models import CustomUser, Conversation, Message, MessageReceipt
+
+
+class Command(BaseCommand):
+    help = "Export a user's data to a zip file"
+
+    def add_arguments(self, parser):
+        parser.add_argument('email')
+
+    def handle(self, email, **options):
+        try:
+            user = CustomUser.objects.get(email=email)
+        except CustomUser.DoesNotExist:
+            raise CommandError('User not found')
+
+        convs = Conversation.objects.filter(Q(user1=user) | Q(user2=user))
+        messages = Message.objects.filter(conversation__in=convs)
+        receipts = MessageReceipt.objects.filter(user=user)
+
+        data = {
+            'profile': json.loads(serializers.serialize('json', [user]))[0],
+            'messages': json.loads(serializers.serialize('json', messages)),
+            'receipts': json.loads(serializers.serialize('json', receipts)),
+        }
+
+        buf = BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('data.json', json.dumps(data, indent=2))
+        filename = f'user_{user.id}_data.zip'
+        with open(filename, 'wb') as fh:
+            fh.write(buf.getvalue())
+        self.stdout.write(self.style.SUCCESS(f'Exported {filename}'))

--- a/ChatApp/tasks.py
+++ b/ChatApp/tasks.py
@@ -17,7 +17,8 @@ for name in (
     if not hasattr(collections, name):
         setattr(collections, name, getattr(collections_abc, name))
 
-from ChatApp.models import Message
+from ChatApp.models import Message, CustomUser, MessageReceipt, Conversation
+from django.db.models import Q
 from pyfcm import FCMNotification
 from apns2.client import APNsClient
 from apns2.payload import Payload
@@ -57,3 +58,20 @@ def send_push(title: str, body: str, tokens: list):
                 client.send_notification(token, payload, settings.APNS_TOPIC)
         except Exception as e:
             logger.error(f"APNS error: {e}")
+
+@shared_task
+def erase_user_data(user_id: int):
+    """Delete a user's personal data."""
+    try:
+        user = CustomUser.objects.get(pk=user_id)
+    except CustomUser.DoesNotExist:
+        return
+
+    MessageReceipt.objects.filter(user=user).delete()
+    messages = Message.objects.filter(
+        Q(sender=user) | Q(conversation__user1=user) | Q(conversation__user2=user)
+    )
+    messages.delete()
+    Conversation.objects.filter(Q(user1=user) | Q(user2=user)).delete()
+    user.delete()
+

--- a/ChatApp/tests/test_gdpr.py
+++ b/ChatApp/tests/test_gdpr.py
@@ -1,0 +1,46 @@
+import json
+import os
+import zipfile
+from django.core.management import call_command
+from django.test import TestCase
+from rest_framework.test import APIClient
+from unittest.mock import patch
+
+from ChatApp.models import CustomUser, Conversation, Message, MessageReceipt
+
+
+class ExportUserDataCommandTest(TestCase):
+    def test_export_user_data(self):
+        user = CustomUser.objects.create_user(email="exp@example.com", password="pass")
+        other = CustomUser.objects.create_user(email="o@example.com", password="pass")
+        conv = Conversation.objects.create(user1=user, user2=other)
+        msg = Message.objects.create(conversation=conv, sender=user, content="hi")
+        MessageReceipt.objects.create(user=user, conversation=conv, last_seen_id=msg.id)
+
+        call_command("export_user_data", "exp@example.com")
+        fname = f"user_{user.id}_data.zip"
+        self.assertTrue(os.path.exists(fname))
+        with zipfile.ZipFile(fname) as zf:
+            data = json.loads(zf.read("data.json").decode())
+        self.assertEqual(data["profile"]["fields"]["email"], "exp@example.com")
+        self.assertEqual(len(data["messages"]), 1)
+        os.remove(fname)
+
+
+class GdprEraseAPITest(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_user(email="gdpr@example.com", password="pass")
+        self.client = APIClient()
+        self.client.login(email="gdpr@example.com", password="pass")
+
+    @patch("ChatApp.tasks.erase_user_data.apply_async")
+    def test_schedule_erase(self, mock_apply):
+        resp = self.client.post("/api/gdpr/erase/", {"confirm": "wrong"}, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        resp = self.client.post("/api/gdpr/erase/", {"confirm": "gdpr@example.com"}, format="json")
+        self.assertEqual(resp.status_code, 200)
+        mock_apply.assert_called_once()
+        args, kwargs = mock_apply.call_args
+        self.assertEqual(args[0][0], self.user.id)
+        self.assertEqual(kwargs.get("countdown"), 30 * 24 * 60 * 60)


### PR DESCRIPTION
## Summary
- add management command `export_user_data` to collect a user's profile, messages and receipts
- schedule user data deletion via new Celery task `erase_user_data`
- expose `/api/gdpr/erase/` to request scheduled erasure
- test data export and erasure logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c3da0708832a8ca99be79817d3f5