### PR TITLE
Add mediasoup huddle namespace and TURN docs

### DIFF
--- a/ChatApp/consumers.py
+++ b/ChatApp/consumers.py
@@ -312,3 +312,23 @@ class ChatConsumer(AsyncWebsocketConsumer):
         except asyncio.CancelledError:
             pass
 
+
+from .huddle.rooms import create_room
+
+
+class HuddleConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        if not self.scope.get("user") or not self.scope["user"].is_authenticated:
+            await self.close()
+            return
+        await self.accept()
+
+    async def receive(self, text_data: str):
+        data = json.loads(text_data)
+        if data.get("action") == "start_huddle":
+            room = create_room()
+            await self.send(text_data=json.dumps({
+                "type": "huddle_started",
+                "roomId": room.id,
+                "routerRtpCapabilities": room.router_rtp_capabilities,
+            }))

--- a/ChatApp/huddle/__init__.py
+++ b/ChatApp/huddle/__init__.py
@@ -1,0 +1,1 @@
+"""Simple huddle room management"""

--- a/ChatApp/huddle/rooms.py
+++ b/ChatApp/huddle/rooms.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+@dataclass
+class HuddleRoom:
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    router_rtp_capabilities: dict = field(default_factory=lambda: {
+        "codecs": [
+            {"kind": "audio", "mimeType": "audio/opus", "clockRate": 48000, "channels": 2},
+            {"kind": "video", "mimeType": "video/VP8", "clockRate": 90000},
+        ],
+        "headerExtensions": [],
+    })
+
+_rooms: dict[str, HuddleRoom] = {}
+
+
+def create_room() -> HuddleRoom:
+    room = HuddleRoom()
+    _rooms[room.id] = room
+    return room

--- a/WebSocketChatApp/routing.py
+++ b/WebSocketChatApp/routing.py
@@ -12,6 +12,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'WebSocketChatApp.settings')
 
 websocket_urlpatterns = [
     re_path(r'ws/chat/(?P<conversation_id>\w+)/$', consumers.ChatConsumer.as_asgi()),
+    re_path(r'ws/huddle/$', consumers.HuddleConsumer.as_asgi()),
 ]
 
 application = ProtocolTypeRouter({

--- a/docs/webrtc.md
+++ b/docs/webrtc.md
@@ -1,0 +1,29 @@
+# WebRTC and Huddle
+
+Huddles use WebRTC for real‑time audio and video. Most clients are behind NATs or firewalls so a TURN server is required for reliable connectivity.
+
+## TURN Setup
+
+Any standards compliant TURN server such as **coturn** can be used. A minimal configuration looks like:
+
+```bash
+sudo apt-get install coturn
+cat <<CONF | sudo tee /etc/turnserver.conf
+listening-port=3478
+fingerprint
+lt-cred-mech
+use-auth-secret
+static-auth-secret=<RANDOM_SECRET>
+CONF
+sudo turnserver -c /etc/turnserver.conf
+```
+
+In `WebSocketChatApp.settings` set the public address and credentials:
+
+```python
+TURN_SERVER = "turn:your-domain:3478"
+TURN_USERNAME = "user"
+TURN_PASSWORD = "pass"
+```
+
+Expose ports 3478 UDP and TCP so peers can reach the server.


### PR DESCRIPTION
## Summary
- create simple huddle room manager
- expose `/ws/huddle/` websocket
- send router RTP capabilities when starting a huddle
- document TURN setup for WebRTC

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AttributeError: module 'collections' has no attribute 'MutableSet')*

------
https://chatgpt.com/codex/tasks/task_e_6844c60fc8a4832aade75df5e5458e33