### PR TITLE
Add Prometheus alerts and Grafana dashboard

### DIFF
--- a/WebSocketChatApp/settings.py
+++ b/WebSocketChatApp/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'channels',
     'csp',
     'rest_framework',
+    'drf_spectacular',
     'ChatApp',
 ]
 
@@ -57,6 +58,10 @@ RATELIMIT_USE_REQUEST_HEADER = True
 
 ROOT_URLCONF = 'WebSocketChatApp.urls'
 SITE_ID = 1
+
+REST_FRAMEWORK = {
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
 
 TEMPLATES = [
     {

--- a/WebSocketChatApp/urls.py
+++ b/WebSocketChatApp/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from django.conf import settings
 
 from ChatApp import views as chat_views
@@ -14,6 +15,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('accounts/', include('allauth.urls')),
     path('api/', include('ChatApp.api_urls')),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='docs'),
 ]
 
 # Gate enterprise features

--- a/docs/grafana-ws-metrics.json
+++ b/docs/grafana-ws-metrics.json
@@ -1,0 +1,69 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      },
+      "title": "WebSocket Connect Success Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "ws_connect_success_rate",
+          "legendFormat": "success rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "seconds"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        }
+      },
+      "title": "P95 WebSocket Latency",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(ws_latency_bucket[5m]))",
+          "legendFormat": "p95 latency",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "title": "WebSocket Metrics",
+  "version": 1
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,247 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /api/gdpr/erase/:
+    post:
+      operationId: gdpr_erase_create
+      tags:
+      - gdpr
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/receipts/:
+    get:
+      operationId: receipts_retrieve
+      tags:
+      - receipts
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/retention/:
+    get:
+      operationId: retention_list
+      tags:
+      - retention
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RetentionPolicy'
+          description: ''
+    post:
+      operationId: retention_create
+      tags:
+      - retention
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetentionPolicy'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/RetentionPolicy'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RetentionPolicy'
+        required: true
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicy'
+          description: ''
+  /api/schema/:
+    get:
+      operationId: schema_retrieve
+      description: |-
+        OpenApi3 schema for this API. Format can be selected via content negotiation.
+
+        - YAML: application/vnd.oai.openapi
+        - JSON: application/vnd.oai.openapi+json
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - json
+          - yaml
+      - in: query
+        name: lang
+        schema:
+          type: string
+          enum:
+          - af
+          - ar
+          - ar-dz
+          - ast
+          - az
+          - be
+          - bg
+          - bn
+          - br
+          - bs
+          - ca
+          - ckb
+          - cs
+          - cy
+          - da
+          - de
+          - dsb
+          - el
+          - en
+          - en-au
+          - en-gb
+          - eo
+          - es
+          - es-ar
+          - es-co
+          - es-mx
+          - es-ni
+          - es-ve
+          - et
+          - eu
+          - fa
+          - fi
+          - fr
+          - fy
+          - ga
+          - gd
+          - gl
+          - he
+          - hi
+          - hr
+          - hsb
+          - hu
+          - hy
+          - ia
+          - id
+          - ig
+          - io
+          - is
+          - it
+          - ja
+          - ka
+          - kab
+          - kk
+          - km
+          - kn
+          - ko
+          - ky
+          - lb
+          - lt
+          - lv
+          - mk
+          - ml
+          - mn
+          - mr
+          - ms
+          - my
+          - nb
+          - ne
+          - nl
+          - nn
+          - os
+          - pa
+          - pl
+          - pt
+          - pt-br
+          - ro
+          - ru
+          - sk
+          - sl
+          - sq
+          - sr
+          - sr-latn
+          - sv
+          - sw
+          - ta
+          - te
+          - tg
+          - th
+          - tk
+          - tr
+          - tt
+          - udm
+          - uk
+          - ur
+          - uz
+          - vi
+          - zh-hans
+          - zh-hant
+      tags:
+      - schema
+      security:
+      - cookieAuth: []
+      - basicAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/yaml:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/vnd.oai.openapi+json:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+components:
+  schemas:
+    RetentionPolicy:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        scope:
+          type: string
+          maxLength: 255
+        ttl_seconds:
+          type: integer
+          maximum: 4294967295
+          minimum: 0
+          format: int64
+        override_until:
+          type: string
+          format: date-time
+          nullable: true
+      required:
+      - id
+      - scope
+      - ttl_seconds
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: sessionid

--- a/helm/chatapp/templates/prometheus-rule.yaml
+++ b/helm/chatapp/templates/prometheus-rule.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "chatapp.fullname" . }}-alerts
+  labels:
+    app: {{ include "chatapp.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  groups:
+    - name: chatapp.rules
+      rules:
+        - alert: WebSocketConnectSuccessRateLow
+          expr: ws_connect_success_rate < 99.9
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "WebSocket connect success rate below 99.9%"
+            description: "WebSocket connection success rate has fallen below 99.9% for the last 5 minutes."
+        - alert: WebSocketLatencyHigh
+          expr: histogram_quantile(0.95, rate(ws_latency_bucket[5m])) > 0.2
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "High WebSocket latency"
+            description: "95th percentile WebSocket latency has exceeded 0.2s for the last 5 minutes."

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,5 +23,6 @@ django-csp~=3.7
 daphne>=3,<4
 python-json-logger~=3.3
 djangorestframework~=3.14.0
+drf-spectacular~=0.27.0
 pyfcm~=2.0
 apns2~=0.7


### PR DESCRIPTION
## Summary
- add PrometheusRule with alerts for WebSocket success rate and latency
- include Grafana dashboard panels for these metrics
- expose `/api/schema` and `/api/docs` using drf-spectacular
- generate `docs/openapi.yaml`

## Testing
- `coverage run --rcfile=.coveragerc --source='.' manage.py test ChatApp.tests --settings=WebSocketChatApp.test_settings`


------
https://chatgpt.com/codex/tasks/task_e_6844dc0c0ff4832a91ec47707d2ff42e