### PR TITLE
Add simple dev auth mode

### DIFF
--- a/ChatApp/management/commands/create_dev_superuser.py
+++ b/ChatApp/management/commands/create_dev_superuser.py
@@ -1,0 +1,20 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+from django.conf import settings
+import os
+
+class Command(BaseCommand):
+    help = "Create a development superuser using DEV_ADMIN_EMAIL and DEV_ADMIN_PASSWORD env vars"
+
+    def handle(self, *args, **options):
+        if not settings.USE_DEV_AUTH:
+            self.stderr.write("USE_DEV_AUTH must be enabled")
+            return
+        User = get_user_model()
+        email = os.getenv('DEV_ADMIN_EMAIL', 'admin@example.com')
+        password = os.getenv('DEV_ADMIN_PASSWORD', 'admin')
+        if User.objects.filter(email=email).exists():
+            self.stdout.write(f"User {email} already exists")
+            return
+        User.objects.create_superuser(email=email, password=password)
+        self.stdout.write(self.style.SUCCESS(f"Created dev superuser {email}"))

--- a/WebSocketChatApp/settings.py
+++ b/WebSocketChatApp/settings.py
@@ -11,12 +11,15 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'insecure-secret-key')
 
+# Toggle builtin username/password auth for development.
+USE_DEV_AUTH = os.getenv('USE_DEV_AUTH', 'False').lower() in ('true', '1', 'yes')
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = [host for host in os.getenv('DJANGO_ALLOWED_HOSTS', '').split(',') if host]
 
-LOGIN_URL = 'login'
+LOGIN_URL = '/accounts/login/' if USE_DEV_AUTH else 'login'
 
 # Application definition
 

--- a/WebSocketChatApp/test_settings.py
+++ b/WebSocketChatApp/test_settings.py
@@ -3,6 +3,9 @@ from collections import abc
 
 from .settings import *  # noqa
 
+# Always use builtin auth in tests
+USE_DEV_AUTH = True
+
 for name in ("MutableSet", "MutableMapping", "MutableSequence", "Mapping", "Iterable"):
     if not hasattr(collections, name):
         setattr(collections, name, getattr(abc, name))

--- a/WebSocketChatApp/urls.py
+++ b/WebSocketChatApp/urls.py
@@ -13,7 +13,14 @@ from chat.licensing import (
 urlpatterns = [
     path('admin/audit-logs/', chat_views.audit_logs_view, name='audit_logs'),
     path('admin/', admin.site.urls),
-    path('accounts/', include('allauth.urls')),
+]
+
+if settings.USE_DEV_AUTH:
+    urlpatterns += [path('accounts/', include('django.contrib.auth.urls'))]
+else:
+    urlpatterns += [path('accounts/', include('allauth.urls'))]
+
+urlpatterns += [
     path('api/', include('ChatApp.api_urls')),
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='docs'),

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Login{% endblock %}
+{% block content %}
+<div class="container mx-auto p-8 max-w-md">
+  <h1 class="text-xl mb-4">Login</h1>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit" class="button-golden mt-4">Sign in</button>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support simple username/password login when `USE_DEV_AUTH=True`
- conditionally include Django auth URLs and adjust `LOGIN_URL`
- add management command to create a development superuser
- add basic login template for built-in auth
- enable dev auth in test settings

## Testing
- `pytest -q`
