### PR TITLE
Add JWT authentication & origin checks for websockets

### DIFF
--- a/ChatApp/middleware.py
+++ b/ChatApp/middleware.py
@@ -2,6 +2,11 @@ import json
 import logging
 from channels.middleware import BaseMiddleware
 from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from channels.db import database_sync_to_async
+from django.core.cache import cache
+import jwt
 
 from .dlp import run_dlp_hook
 
@@ -29,3 +34,60 @@ class DLPWebSocketMiddleware(BaseMiddleware):
             await send(message)
 
         return await super().__call__(scope, receive, send_wrapper)
+
+
+class JWTAuthMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        if not scope.get("user") or not getattr(scope.get("user"), "is_authenticated", False):
+            token = None
+            query_string = scope.get("query_string", b"").decode()
+            if query_string:
+                from urllib.parse import parse_qs
+                qs = parse_qs(query_string)
+                token = qs.get("token", [None])[0]
+
+            if not token:
+                headers = dict(scope.get("headers", []))
+                auth_header = headers.get(b"authorization")
+                if auth_header:
+                    auth_value = auth_header.decode()
+                    if auth_value.lower().startswith("bearer "):
+                        token = auth_value.split(" ", 1)[1]
+
+            if token:
+                try:
+                    payload = jwt.decode(
+                        token,
+                        getattr(settings, "JWT_SECRET_KEY", settings.SECRET_KEY),
+                        algorithms=[getattr(settings, "JWT_ALGORITHM", "HS256")],
+                    )
+                    user = await database_sync_to_async(get_user_model().objects.get)(id=payload.get("user_id"))
+                    scope["user"] = user
+                except Exception:
+                    scope["user"] = AnonymousUser()
+            else:
+                scope["user"] = AnonymousUser()
+
+        return await super().__call__(scope, receive, send)
+
+
+class WebSocketRateLimitMiddleware(BaseMiddleware):
+    async def __call__(self, scope, receive, send):
+        user = scope.get("user")
+        ip = scope.get("client", [None])[0]
+        identifier = f"user:{getattr(user, 'id', 'anon')}|ip:{ip}"
+        limit = int(getattr(settings, "WS_CONNECTION_LIMIT", 5))
+        key = f"wsconn:{identifier}"
+        count = cache.get(key, 0)
+        if count >= limit:
+            await send({"type": "websocket.close"})
+            return
+        cache.set(key, count + 1, timeout=60)
+        try:
+            return await super().__call__(scope, receive, send)
+        finally:
+            remaining = cache.get(key, 1)
+            if remaining > 1:
+                cache.decr(key)
+            else:
+                cache.delete(key)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ The WebSocket Chat Application demonstrates real-time messaging using Django, Dj
 - Live chat over WebSocket connections
 - Persistent conversation and message history
 - Rate limiting on HTTP views and WebSocket endpoints
+- JWT-secured WebSocket authentication
 - Robust form validation and logging
 - Message sanitisation and length checks for extra security
+- HTTPS enforcement and secure cookies in production
 - WebSocket connections automatically use `wss://` when the site is served over HTTPS
 - Typing indicators show when participants are composing a message
 - End-to-end encryption for 1-to-1 chats uses the double-ratchet algorithm with

--- a/WebSocketChatApp/routing.py
+++ b/WebSocketChatApp/routing.py
@@ -1,10 +1,15 @@
 import os
 
-from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
-from ChatApp.middleware import DLPWebSocketMiddleware
+from channels.security.websocket import OriginValidator
+from ChatApp.middleware import (
+    DLPWebSocketMiddleware,
+    JWTAuthMiddleware,
+    WebSocketRateLimitMiddleware,
+)
 from django.core.asgi import get_asgi_application
 from django.urls import re_path
+from django.conf import settings
 
 from ChatApp import consumers
 
@@ -16,13 +21,18 @@ websocket_urlpatterns = [
     re_path(r'ws/huddle/$', consumers.HuddleConsumer.as_asgi()),
 ]
 
-application = ProtocolTypeRouter({
-    "http": get_asgi_application(),
-    "websocket": AuthMiddlewareStack(
-        DLPWebSocketMiddleware(
-            URLRouter(
-                websocket_urlpatterns
-            )
-        )
-    ),
-})
+application = ProtocolTypeRouter(
+    {
+        "http": get_asgi_application(),
+        "websocket": OriginValidator(
+            JWTAuthMiddleware(
+                WebSocketRateLimitMiddleware(
+                    DLPWebSocketMiddleware(
+                        URLRouter(websocket_urlpatterns)
+                    )
+                )
+            ),
+            getattr(settings, "WEBSOCKET_ALLOWED_ORIGINS", []),
+        ),
+    }
+)

--- a/WebSocketChatApp/settings.py
+++ b/WebSocketChatApp/settings.py
@@ -197,13 +197,29 @@ CHANNEL_LAYERS = {
     },
 }
 
+# JSON Web Token settings for WebSocket authentication
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", SECRET_KEY)
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+
+# Allowed origins for WebSocket handshake
+WEBSOCKET_ALLOWED_ORIGINS = [
+    origin
+    for origin in os.getenv("WEBSOCKET_ALLOWED_ORIGINS", "*").split(",")
+    if origin
+]
+
+# Maximum simultaneous WebSocket connections per minute per user/IP
+WS_CONNECTION_LIMIT = int(os.getenv("WS_CONNECTION_LIMIT", "5"))
+
 # Security hardening
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 SESSION_COOKIE_SECURE = not DEBUG
 CSRF_COOKIE_SECURE = not DEBUG
 X_FRAME_OPTIONS = 'DENY'
-SECURE_SSL_REDIRECT = os.getenv('DJANGO_SECURE_SSL_REDIRECT', 'False').lower() in ('true', '1', 'yes')
+SECURE_SSL_REDIRECT = os.getenv(
+    'DJANGO_SECURE_SSL_REDIRECT', 'False' if DEBUG else 'True'
+).lower() in ('true', '1', 'yes')
 SECURE_HSTS_SECONDS = int(os.getenv('DJANGO_SECURE_HSTS_SECONDS', '0' if DEBUG else '3600'))
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 SECURE_HSTS_PRELOAD = True

--- a/WebSocketChatApp/test_settings.py
+++ b/WebSocketChatApp/test_settings.py
@@ -54,3 +54,6 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels.layers.InMemoryChannelLayer",
     }
 }
+
+# Disable HTTPS redirection in tests to avoid unexpected 301 responses
+SECURE_SSL_REDIRECT = False

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -5,6 +5,8 @@ from unittest.mock import patch, MagicMock
 
 from WebSocketChatApp.routing import application
 from ChatApp.models import CustomUser, Conversation
+from django.conf import settings
+import jwt
 
 
 class WebSocketIntegrationTests(TransactionTestCase):
@@ -52,3 +54,23 @@ class WebSocketIntegrationTests(TransactionTestCase):
 
         messages = list(convo.messages.values_list("content", flat=True))
         assert messages == contents
+
+    def test_jwt_authentication(self):
+        user = CustomUser.objects.create_user(email="jwt@example.com", password="pass")
+        convo = Conversation.objects.create(user1=user, user2=user)
+
+        token = jwt.encode({"user_id": user.id}, settings.JWT_SECRET_KEY, algorithm=settings.JWT_ALGORITHM)
+
+        async def inner():
+            with patch("ChatApp.consumers.redis.StrictRedis") as mock_redis:
+                mock_client = MagicMock()
+                mock_redis.return_value.__enter__.return_value = mock_client
+
+                communicator = WebsocketCommunicator(
+                    application, f"ws/chat/{convo.id}/?token={token}"
+                )
+                connected, _ = await communicator.connect()
+                assert connected
+                await communicator.disconnect()
+
+        async_to_sync(inner)()


### PR DESCRIPTION
## Summary
- add JWT authentication and connection rate limiting middleware
- restrict websocket origins via OriginValidator
- enforce HTTPS and secure cookies by default
- document JWT auth in README
- test JWT websocket auth

## Testing
- `pytest -q`